### PR TITLE
[Feature]Fixed the warning the console

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Barlow|Barlow+Condensed" rel="stylesheet">
     <link href="/static/wikifont/wikiglyphs.css" rel="stylesheet">
     <link href="/static/flag-icon-css/css/flag-icon.min.css" rel="stylesheet">
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()">
     <link href='https://api.mapbox.com/mapbox-gl-js/v1.10.1/mapbox-gl.css' rel='stylesheet' />
     <link rel="icon" href="static/favicon.ico">
     <title>Wikidocumentaries</title>


### PR DESCRIPTION
The meta tag with `http-equiv="Permissions-Policy"` and `content="interest-cohort=()"` sets a Permissions Policy for a web page that controls whether or not the browser can enable the FLoC (Federated Learning of Cohorts) API, which is used for targeted advertising. The interest-cohort=() value specifically disables the use of the FLoC API on the page.